### PR TITLE
Specify python version in pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,3 +14,4 @@ jobs:
         uses: JRubics/poetry-publish@v2.0
         with:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
+          python_version: '3.11'


### PR DESCRIPTION
This PR specifies the python version as 3.11 in the pypi publication workflow.