### PR TITLE
Write json file containing list of available fields

### DIFF
--- a/tools/combine_preds.py
+++ b/tools/combine_preds.py
@@ -105,9 +105,10 @@ def combine_preds(
     ]
     done_fields.sort()
 
-    # Write json file containing field list
-    with open(path_to_preds / combined_preds_dirname / "fields.json", "w") as f:
-        json.dump(done_fields, f)
+    if save:
+        # Write json file containing field list
+        with open(path_to_preds / combined_preds_dirname / "fields.json", "w") as f:
+            json.dump(done_fields, f)
 
     preds_to_save = None
     counter = 0

--- a/tools/combine_preds.py
+++ b/tools/combine_preds.py
@@ -103,10 +103,15 @@ def combine_preds(
         str(x).split("/")[-1].split(".")[0]
         for x in (path_to_preds / combined_preds_dirname).glob("field_*.parquet")
     ]
+    done_fields.sort()
+
+    # Write json file containing field list
+    with open(path_to_preds / combined_preds_dirname / "fields.json", "w") as f:
+        json.dump(done_fields, f)
 
     preds_to_save = None
     counter = 0
-    print(f"Processing {len(fields_dnn_dict)} fields/files...")
+    print(f"Processing {len(fields_dnn_dict) - len(done_fields)} fields/files...")
 
     for field in fields_dnn_dict.keys():
         if field not in done_fields:


### PR DESCRIPTION
This PR modifies `combine_preds.py` to write a json file containing a list of all available fields. This list will be added to the Zenodo record to describe which fields can be downloaded.