### PR TITLE
Add zenodo release documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,4 +10,5 @@ ZTF Variable Source Classification Project
    scanner
    field_guide
    allocation
+   zenodo
    license

--- a/doc/zenodo.md
+++ b/doc/zenodo.md
@@ -28,4 +28,4 @@ Finally, create release notes by clicking "Add description" and choosing "Notes"
 
 ## Adding new users
 
-The "ZTF Source Classification Project" community [`ztf-scope`](https://zenodo.org/communities/ztf-scope) contains the current data repository. Inviting additional Zenodo users to this community as Curators will allow them to manage the repository and create new versions.
+The "ZTF Source Classification Project" community [ztf-scope](https://zenodo.org/communities/ztf-scope) contains the current data repository. Inviting additional Zenodo users to this community as Curators will allow them to manage the repository and create new versions.

--- a/doc/zenodo.md
+++ b/doc/zenodo.md
@@ -2,8 +2,6 @@
 
 As more ZTF fields receive SCoPe classifications, we will want to make them public on Zenodo. This page describes the data products available and provides a guide to preparing/publishing new data releases.
 
-**Note: at time of writing, Zenodo only supports new releases from the original repository author. Please reach out to Brian Healy to assist with authoring a new release.**
-
 ## Data product description
 
 The most recent data release contains these components:
@@ -29,3 +27,7 @@ To begin a new release draft, click "New version" on the current release. The ma
 To publish a new release after uploading the latest classification catalog, first ensure that all desired files are in place. Then, click "Get a DOI now!" to reserve a version-specific DOI for this release. Additionally, specify the publication date and version in `vX.Y.Z` format.
 
 Finally, create release notes by clicking "Add description" and choosing "Notes" under the "Type" dropdown. These release notes should specify what has changed from one version to the next.
+
+## Adding new users
+
+The "ZTF Source Classification Project" community [`ztf-scope`](https://zenodo.org/communities/ztf-scope) contains the current data repository. Inviting additional Zenodo users to this community as Curators will allow them to manage the repository and create new versions.

--- a/doc/zenodo.md
+++ b/doc/zenodo.md
@@ -1,6 +1,6 @@
 # Data Releases on Zenodo
 
-As more ZTF fields receive SCoPe classifications, we will want to make them public on Zenodo. This page describes the data products available and provides a guide to preparing/publishing new data releases.
+As more ZTF fields receive SCoPe classifications, we make them public on Zenodo. This page describes the data products available and provides a guide to preparing/publishing new data releases. The permanent link for the SCoPe III repository on Zenodo is [https://zenodo.org/doi/10.5281/zenodo.8410825](https://zenodo.org/doi/10.5281/zenodo.8410825). This link will always resolve to the latest data release.
 
 ## Data product description
 
@@ -18,9 +18,7 @@ The most recent data release contains these components:
 
 ## Preparing a new release
 
-The permanent link for the SCoPe repository on Zenodo is [https://zenodo.org/doi/10.5281/zenodo.8410825](https://zenodo.org/doi/10.5281/zenodo.8410825). This link will always resolve to the latest data release.
-
-To begin a new release draft, click "New version" on the current release. The main difference between releases is the classification catalog, which adds more ZTF fields over time, along with `fields.json`. Other unchanged elements of the release may be imported from the previous release by clicking "Import files".
+To begin a new release draft, click "New version" on the current release. The main difference between releases is the classification catalog Zip file, which adds more ZTF fields over time, along with `fields.json`. Other unchanged elements of the release may be imported from the previous release by clicking "Import files".
 
 ## Publishing a new release
 

--- a/doc/zenodo.md
+++ b/doc/zenodo.md
@@ -1,0 +1,31 @@
+# Data Releases on Zenodo
+
+As more ZTF fields receive SCoPe classifications, we will want to make them public on Zenodo. This page describes the data products available and provides a guide to preparing/publishing new data releases.
+
+**Note: at time of writing, Zenodo only supports new releases from the original repository author. Please reach out to Brian Healy to assist with authoring a new release.**
+
+## Data product description
+
+The most recent data release contains these components:
+
+| file | description |
+| -------------- | ------------ |
+| field_296_100rows.csv | Demo predictions file containing 100 classified light curves |
+| fields.json | List of fields in classification catalog, generated when running `combine-preds` |
+| predictions_dnn_xgb_*N*_fields.zip | Zip file containing classification catalog (contains *N* combined DNN/XGB prediction files in CSV format) |
+| SCoPe_classification_demo.ipynb | Notebook interacting with demo predictions |
+| trained_dnn_models.zip | Zip file containing trained DNN models |
+| trained_xgb_models.zip | Zip file containing trained XGB models |
+| training_set.parquet | Parquet file containing training set |
+
+## Preparing a new release
+
+The permanent link for the SCoPe repository on Zenodo is [https://zenodo.org/doi/10.5281/zenodo.8410825](https://zenodo.org/doi/10.5281/zenodo.8410825). This link will always resolve to the latest data release.
+
+To begin a new release draft, click "New version" on the current release. The main difference between releases is the classification catalog, which adds more ZTF fields over time, along with `fields.json`. Other unchanged elements of the release may be imported from the previous release by clicking "Import files".
+
+## Publishing a new release
+
+To publish a new release after uploading the latest classification catalog, first ensure that all desired files are in place. Then, click "Get a DOI now!" to reserve a version-specific DOI for this release. Additionally, specify the publication date and version in `vX.Y.Z` format.
+
+Finally, create release notes by clicking "Add description" and choosing "Notes" under the "Type" dropdown. These release notes should specify what has changed from one version to the next.


### PR DESCRIPTION
This PR adds a docs page describing zenodo data releases and how to prepare/publish new versions.