### PR TITLE
Add cython requirement for periodfind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ xgboost = ">=1.7.5"
 seaborn = ">=0.12.2"
 pydot = ">=1.4.2"
 notebook = ">=7.0.6"
+cython = ">=3.0.10"
 tables = ">=3.7,<3.9.2"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ questionary>=1.8.1
 scikit-learn>=0.24.1
 tensorflow>=2.14.0,<=2.15.0
 wandb>=0.12.1
+cython>=3.0.10


### PR DESCRIPTION
This PR adds a cython requirement to make `periodfind` installations easier on cluster resources.