### PR TITLE
Fix path bug in get_features.py

### DIFF
--- a/tools/get_features.py
+++ b/tools/get_features.py
@@ -159,8 +159,8 @@ def get_features_loop(
 
     if not whole_field:
         outfile = (
-            os.path.dirname(__file__)
-            + "/../features/field_"
+            str(BASE_DIR)
+            + "/features/field_"
             + str(field)
             + "/ccd_"
             + str(ccd).zfill(2)
@@ -170,8 +170,8 @@ def get_features_loop(
 
     else:
         outfile = (
-            os.path.dirname(__file__)
-            + "/../features/field_"
+            str(BASE_DIR)
+            + "/features/field_"
             + str(field)
             + "/"
             + "field_"


### PR DESCRIPTION
This PR fixes a bug in which the wrong path is used by pip-installed scope when testing `get_features.py`. 