### PR TITLE
Update slurm script generators with NSCA Delta specifics

### DIFF
--- a/tools/combine_preds_slurm.py
+++ b/tools/combine_preds_slurm.py
@@ -128,6 +128,10 @@ def main():
     if args.cluster_name in ['Expanse', 'expanse', 'EXPANSE']:
         fid.write('module purge\n')
         fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        fid.write('module add anaconda3_cpu\n')
+        fid.write(f'source activate {args.python_env_name}\n')
 
     fid.write(
         'combine-preds --path-to-preds %s --combined-preds-dirname %s --specific-field %s --dateobs %s --dnn-directory %s --xgb-directory %s --agg-method %s --p-threshold %s %s \n'

--- a/tools/generate_features_slurm.py
+++ b/tools/generate_features_slurm.py
@@ -425,6 +425,12 @@ def main():
         fid.write('module add gpu/0.15.4\n')
         fid.write('module add cuda\n')
         fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        fid.write('module add anaconda3_gpu\n')
+        fid.write('module add cuda\n')
+        fid.write('module add gcc-runtime\n')
+        fid.write(f'source activate {args.python_env_name}\n')
 
     if args.doQuadrantFile:
         qid = '$QID'
@@ -501,6 +507,10 @@ def main():
     if args.cluster_name in ['Expanse', 'expanse', 'EXPANSE']:
         fid.write('module purge\n')
         fid.write('module add slurm\n')
+        fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        fid.write('module add anaconda3_cpu\n')
         fid.write(f'source activate {args.python_env_name}\n')
 
     if not args.doSubmitLoop:

--- a/tools/run_inference_slurm.py
+++ b/tools/run_inference_slurm.py
@@ -180,6 +180,15 @@ def main():
             fid.write('module add gpu/0.15.4\n')
             fid.write('module add cuda\n')
         fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        if args.gpus > 0:
+            fid.write('module add anaconda3_gpu\n')
+            fid.write('module add cuda\n')
+            fid.write('module add gcc-runtime\n')
+        else:
+            fid.write('module add anaconda3_cpu\n')
+        fid.write(f'source activate {args.python_env_name}\n')
 
     fid.write(f"{script_path} $FID" + '\n')
     fid.close()
@@ -203,6 +212,10 @@ def main():
     if args.cluster_name in ['Expanse', 'expanse', 'EXPANSE']:
         fid.write('module purge\n')
         fid.write('module add slurm\n')
+        fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        fid.write('module add anaconda3_cpu\n')
         fid.write(f'source activate {args.python_env_name}\n')
 
     fid.write(

--- a/tools/train_algorithm_slurm.py
+++ b/tools/train_algorithm_slurm.py
@@ -229,6 +229,15 @@ def main():
             fid.write('module add gpu/0.15.4\n')
             fid.write('module add cuda\n')
         fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        if args.gpus > 0:
+            fid.write('module add anaconda3_gpu\n')
+            fid.write('module add cuda\n')
+            fid.write('module add gcc-runtime\n')
+        else:
+            fid.write('module add anaconda3_cpu\n')
+        fid.write(f'source activate {args.python_env_name}\n')
 
     fid.write("scope-train " + "--tag $TID " + " ".join(line_info) + '\n')
     fid.close()
@@ -252,6 +261,10 @@ def main():
     if args.cluster_name in ['Expanse', 'expanse', 'EXPANSE']:
         fid.write('module purge\n')
         fid.write('module add slurm\n')
+        fid.write(f'source activate {args.python_env_name}\n')
+    elif args.cluster_name in ['Delta', 'delta', 'DELTA']:
+        fid.write('module purge\n')
+        fid.write('module add anaconda3_cpu\n')
         fid.write(f'source activate {args.python_env_name}\n')
 
     if args.sweep:


### PR DESCRIPTION
This PR updates all slurm script generators to include specific lines for NSCA Delta. Note that while scope feature generation runs on Delta GPUs, at the moment it appears to take ~2x as long to complete compared to Expanse. This seems too slow for A100s but also too fast to be avoiding the GPUs altogether. 